### PR TITLE
Added loadFont() and sourceURL feature for include()

### DIFF
--- a/Desktop/ejecta.js
+++ b/Desktop/ejecta.js
@@ -3,7 +3,11 @@ var ejecta =
 {
 	include : function(src)
 	{
-		// includes are pre-parsed, inserted, and eval'd below
+		var request = new XMLHttpRequest();
+		
+		request.open('GET', src, false);
+		request.send();
+		eval(request.responseText + "\n //@ sourceURL=" + src);
 	},
 	openURL : function(url, message)
 	{
@@ -18,31 +22,4 @@ window.requestAnimationFrame = window.webkitRequestAnimationFrame;
 
 // use `if (window.Ejecta) console.log('native');` to block native features like GameCenter
 
-// extra-dirty JavaScript includes
-var included = [];
-function parseEjectaIncludes(src)
-{
-	if (included[src]) return '';
-	included[src] = true;
-	
-	var request = new XMLHttpRequest();
-	request.open('GET', src, false); // synchronous
-	request.send();
-	
-	var js = request.responseText;
-	
-	var m = js.match(/ejecta\.include\(([^\)]+)\);/g);
-	if (m!=null)
-	{
-		for (var i=0; i<m.length; i++)
-		{
-			var n = m[i].match(/(['"])([^'"]+)/);
-			if (n != null)
-			{
-				js = js.replace(m[i], parseEjectaIncludes(n[2]));
-			}
-		}
-	}
-	return js;
-}
-eval(parseEjectaIncludes('index.js'));
+ejecta.include('index.js');

--- a/Desktop/ejecta.js
+++ b/Desktop/ejecta.js
@@ -1,7 +1,6 @@
 // An Ejecta polyfill for developing in desktop Safari
 var ejecta = 
 {
-	landscapeMode : canvas.width > canvas.height,
 	include : function(src)
 	{
 		// includes are pre-parsed, inserted, and eval'd below

--- a/Desktop/ejecta.js
+++ b/Desktop/ejecta.js
@@ -16,6 +16,19 @@ var ejecta =
 	getText : function(title, message, callback)
 	{
 		callback(window.prompt(message));
+	},
+	loadFont: function(file)
+	{
+		var name = file.replace(/^.*\/|\.[^\.]*$/g,'');
+		var newStyle = document.createElement('style');
+		newStyle.appendChild(document.createTextNode(
+			"@font-face {\n" +
+				"font-family: '" + name + "';\n" +
+				"src: url('" + file + "');\n" +
+			"}"
+		));
+		
+		document.head.appendChild(newStyle);
 	}
 };
 window.requestAnimationFrame = window.webkitRequestAnimationFrame;


### PR DESCRIPTION
This adds the `ejecta.loadFont()` function (that was absent in the Ejecta documentation just a few minutes ago).

The `sourceURL` is added for includes for proper file names in error messages. It also omits the `included` check (just like Ejecta proper) so you can create infinite include loops if you want to...

I'm not sure if I'm missing something by making `ejecta.include()` a proper function instead of the regexp replace!?

`ejecta.landscapeMode` was removed in the latest Ejecta version (again, outdated documentation, sorry).
