### PR TITLE
Fixed ejecta.include to eval in global scope

### DIFF
--- a/Desktop/ejecta.js
+++ b/Desktop/ejecta.js
@@ -3,7 +3,11 @@ var ejecta =
 {
 	include : function(src)
 	{
-		// includes are pre-parsed, inserted, and eval'd below
+		var request = new XMLHttpRequest();
+		
+		request.open('GET', src, false);
+		request.send();
+		eval.call(window, request.responseText + "\n //@ sourceURL=" + src);
 	},
 	openURL : function(url, message)
 	{
@@ -31,31 +35,4 @@ window.requestAnimationFrame = window.webkitRequestAnimationFrame;
 
 // use `if (window.Ejecta) console.log('native');` to block native features like GameCenter
 
-// extra-dirty JavaScript includes
-var included = [];
-function parseEjectaIncludes(src)
-{
-	if (included[src]) return '';
-	included[src] = true;
-	
-	var request = new XMLHttpRequest();
-	request.open('GET', src, false); // synchronous
-	request.send();
-	
-	var js = request.responseText;
-	
-	var m = js.match(/ejecta\.include\(([^\)]+)\);/g);
-	if (m!=null)
-	{
-		for (var i=0; i<m.length; i++)
-		{
-			var n = m[i].match(/(['"])([^'"]+)/);
-			if (n != null)
-			{
-				js = js.replace(m[i], parseEjectaIncludes(n[2]));
-			}
-		}
-	}
-	return js;
-}
-eval(parseEjectaIncludes('index.js'));
+ejecta.include('index.js');


### PR DESCRIPTION
This should always `eval()` included files in global scope, just like with the regexp.
